### PR TITLE
tw - create database table for MenuItemReviews

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/** 
+ * This is a JPA entity that represents a Menu Item Review
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "MenuItemReviews")
+public class MenuItemReview {
+  @Id
+  private String id;
+  private Long itemId;
+  private String reviewerEmail;
+  private int stars;
+  private LocalDateTime dateReviewed;
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemsReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemsReviewRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDiningCommonsRepository is a repository for MenuItemReview entities
+ */
+@Repository
+public interface MenuItemsReviewRepository extends CrudRepository<MenuItemReview, String> {
+ 
+}

--- a/src/main/resources/db/migration/changes/MenuItemReviews.json
+++ b/src/main/resources/db/migration/changes/MenuItemReviews.json
@@ -1,0 +1,80 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "MenuItemReviews-1",
+          "author": "Tyler-W0ng",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEWS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEMREVIEWS_PK"
+                      },
+                      "name": "ID",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ITEM_ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "REVIEWER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "STARS",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REVIEWED",
+                      "type": "TIMESTAMP WITH TIME ZONE"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMENTS",
+                      "type": "VARCHAR(255)"
+                    }
+                  }]
+                ,
+                "tableName": "MENUITEMREVIEWS"
+              }
+            }]
+
+        }
+    }
+]}


### PR DESCRIPTION
Closes #26 

In this PR, I added a database table that represents a MenuItemReview with the following fields:

```
Varchar(255) Id
BigInt Item_id
Varchar(255) Reviewer_email
BigInt Stars
Timestamp With Time Zone Date_reviewed
Varchar(255) Comments
```

You can test this by running on localhost and looking for the MenuItemReviews table on the h2-console

![image](https://github.com/user-attachments/assets/4d2ebcc8-b00f-4852-bf19-d82ecaef276f)

You can also test this by running on dokku and connecting to the postgres database, and running \dt:

```
tyler_wong@dokku-15:~$ dokku postgres:connect team01-dev-tyler-w0ng-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_tyler_w0ng_db=# \dt
                 List of relations
 Schema |         Name          | Type  |  Owner
--------+-----------------------+-------+----------
 public | databasechangelog     | table | postgres
 public | databasechangeloglock | table | postgres
 public | menuitemreviews       | table | postgres
 public | restaurants           | table | postgres
 public | ucsbdates             | table | postgres
 public | ucsbdiningcommons     | table | postgres
 public | users                 | table | postgres
(7 rows)

team01_dev_tyler_w0ng_db=#
```