### PR TITLE
Create db table for Articles

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a Article, i.e. an entry
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "articles")
+public class Articles {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String title;
+  private String url;
+  private String explanation;
+  private String email;
+  private LocalDateTime dateAdded;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Articles;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The ArticlesRepository is a repository for Articles entities.
+ */
+
+@Repository
+public interface ArticlesRepository extends CrudRepository<Articles, Long> {
+
+}

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "Articles-1",
+          "author": "bryceinouye",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "ARTICLES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "ARTICLES_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                      "column": {
+                          "name": "TITLE",
+                          "type": "VARCHAR(255)"
+                        }
+                    },
+                    {
+                        "column": {
+                            "name": "URL",
+                            "type": "VARCHAR(255)"
+                        }
+                    },
+                    {
+                        "column": {
+                            "name": "EXPLANATION",
+                            "type": "VARCHAR(255)"
+                        }
+                    },
+                    {
+                        "column": {
+                            "name": "EMAIL",
+                            "type": "VARCHAR(255)"
+                        }
+                    },
+                    {
+                      "column": {
+                        "name": "DATE_ADDED",
+                        "type": "TIMESTAMP"
+                      }
+                    }
+                ],
+                "tableName": "ARTICLES"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
## Overview
This PR adds a PostgreSQL database table that name `Articles`, which is intended to store blog posts, newspaper articles, etc. 

## Table Fields
The `Articles` table contains the following fields:

```
String title
String url
String explanation
String email (of person that submitted it)
LocalDateTime dateAdded
```

## Testing Instructions
1. Running Locally
You can test this by running on localhost and looking for the **ARTICLES** tab on the `/h2-console`:
![image](https://github.com/user-attachments/assets/c19c5fc7-d618-4e6a-82f6-f3966cab334c)
2. Running on Dokku
You can also test this by running on dokku and connecting to the PostGreSQL database, and running `\dt`:
```
                 List of relations
 Schema |         Name          | Type  |  Owner   
--------+-----------------------+-------+----------
 public | articles              | table | postgres
 public | databasechangelog     | table | postgres
 public | databasechangeloglock | table | postgres
 public | restaurants           | table | postgres
 public | ucsbdates             | table | postgres
 public | ucsbdiningcommons     | table | postgres
 public | users                 | table | postgres
(7 rows)
```
## Extra Information
I am not yet familiar with the pull request standards for this class, so please let me know if this is not detailed enough, too detailed, or if I've missed anything. Thanks!

Closes #38 