### PR TITLE
Added put mapping and tests to UCSBDiningCommonsMenuItem

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -96,4 +96,30 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
 
         return savedUcsbDiningCommonsMenuItem;
     }
+
+    /**
+     * Update a single dining commons menu item 
+     * 
+     * @param id       id of the diningcommonsmenuitem to update
+     * @param incoming the new diningcommonsmenuitem
+     * @return the updated diningcommonsmenuitem object
+     */
+    @Operation(summary= "Update a single dining commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        ucsbDiningCommonsMenuItem.setDiningCommonsCode(incoming.getDiningCommonsCode());
+        ucsbDiningCommonsMenuItem.setName(incoming.getName());
+        ucsbDiningCommonsMenuItem.setStation(incoming.getStation());
+
+        ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+        return ucsbDiningCommonsMenuItem;
+    }
 }


### PR DESCRIPTION
Added put mapping and tests to UCSBDiningCommonsMenuItem, according to instructions on linked issue.

The endpoint is available on Swagger on both localhost and Dokku, and functions on both. 