### PR TITLE
Bi articles create delete

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.Articles;
-import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 
@@ -108,4 +107,50 @@ public class ArticlesController extends ApiController {
 
         return savedArticles;
     }
+
+    /**
+     * Delete an Articles entry
+     * 
+     * @param id the id of the articles entry to delete
+     * @return a message indicating the articles entry was deleted
+     */
+    @Operation(summary= "Delete a Articles entry")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteArticles(
+            @Parameter(name="id") @RequestParam Long id) {
+        Articles articles = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+        articlesRepository.delete(articles);
+        return genericMessage("Articles with id %s deleted".formatted(id));
+    }
+
+    // /**
+    //  * Update a single date
+    //  * 
+    //  * @param id       id of the date to update
+    //  * @param incoming the new articles entry
+    //  * @return the updated articles object
+    //  */
+    // @Operation(summary= "Update a single articles entry")
+    // @PreAuthorize("hasRole('ROLE_ADMIN')")
+    // @PutMapping("")
+    // public Articles updateArticles(
+    //         @Parameter(name="id") @RequestParam Long id,
+    //         @RequestBody @Valid Articles incoming) {
+
+    //     Articles articles = articlesRepository.findById(id)
+    //             .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    //     articles.setTitle(incoming.getTitle());
+    //     articles.setUrl(incoming.getUrl());
+    //     articles.setExplanation(incoming.getExplanation());
+    //     articles.setEmail(incoming.getEmail());
+    //     articles.setDateAdded(incoming.getDateAdded());
+
+    //     articlesRepository.save(articles);
+
+    //     return articles;
+    // }
 }


### PR DESCRIPTION
### Overview
This PR adds a DELETE endpoint for `Articles` database.

### Changes Made
- Implemented logic to get single articles instance by id.
- Added corresponding unit tests in ArticleControllerTests.java.
- Synced changes with Dokku at team01-dev-bryceinouye.

### Testing Instructions
1. Running locally
You can test this by running on localhost and going to the **Swagger API Links**. Here, scroll down to the `Articles` section to test the `DELETE` endpoint.
![image](https://github.com/user-attachments/assets/7ad603d7-2ea2-4727-b2ca-348da7177fbf)You can also run the command `mvn test jacoco:report` and review the report at `target/site/jacoco/index.html`.  
![image](https://github.com/user-attachments/assets/6f060d71-f0bb-495f-8b84-6b7c4c7d2749)
2. Running on Dokku
Similar to 1, you can test this by running the [web application ](https://team01-dev-bryceinouye.dokku-15.cs.ucsb.edu/) and going to the **Swagger API Links**. From there, scroll down to the `Articles` section to test the `DELETE` endpoint.

### Extra Information
Closes #42