### PR TITLE
Bi articles create put

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.Articles;
-import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 
@@ -108,4 +107,50 @@ public class ArticlesController extends ApiController {
 
         return savedArticles;
     }
+
+    /**
+     * Delete an Articles entry
+     * 
+     * @param id the id of the articles entry to delete
+     * @return a message indicating the articles entry was deleted
+     */
+    @Operation(summary= "Delete a Articles entry")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteArticles(
+            @Parameter(name="id") @RequestParam Long id) {
+        Articles articles = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+        articlesRepository.delete(articles);
+        return genericMessage("Articles with id %s deleted".formatted(id));
+    }
+
+    // /**
+    //  * Update a single date
+    //  * 
+    //  * @param id       id of the date to update
+    //  * @param incoming the new articles entry
+    //  * @return the updated articles object
+    //  */
+    // @Operation(summary= "Update a single articles entry")
+    // @PreAuthorize("hasRole('ROLE_ADMIN')")
+    // @PutMapping("")
+    // public Articles updateArticles(
+    //         @Parameter(name="id") @RequestParam Long id,
+    //         @RequestBody @Valid Articles incoming) {
+
+    //     Articles articles = articlesRepository.findById(id)
+    //             .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    //     articles.setTitle(incoming.getTitle());
+    //     articles.setUrl(incoming.getUrl());
+    //     articles.setExplanation(incoming.getExplanation());
+    //     articles.setEmail(incoming.getEmail());
+    //     articles.setDateAdded(incoming.getDateAdded());
+
+    //     articlesRepository.save(articles);
+
+    //     return articles;
+    // }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -55,6 +55,23 @@ public class ArticlesController extends ApiController {
     }
 
     /**
+     * Get a single articles by id
+     * 
+     * @param id the id of the articles instance
+     * @return a articles instance
+     */
+    @Operation(summary= "Get a single articles instance")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Articles getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        Articles articles = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+        return articles;
+    }
+
+    /**
      * Create a new articles entry
      * 
      * @param title         title of the article

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -126,31 +126,31 @@ public class ArticlesController extends ApiController {
         return genericMessage("Articles with id %s deleted".formatted(id));
     }
 
-    // /**
-    //  * Update a single date
-    //  * 
-    //  * @param id       id of the date to update
-    //  * @param incoming the new articles entry
-    //  * @return the updated articles object
-    //  */
-    // @Operation(summary= "Update a single articles entry")
-    // @PreAuthorize("hasRole('ROLE_ADMIN')")
-    // @PutMapping("")
-    // public Articles updateArticles(
-    //         @Parameter(name="id") @RequestParam Long id,
-    //         @RequestBody @Valid Articles incoming) {
+    /**
+     * Update a single date
+     * 
+     * @param id       id of the date to update
+     * @param incoming the new articles entry
+     * @return the updated articles object
+     */
+    @Operation(summary= "Update a single articles entry")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public Articles updateArticles(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid Articles incoming) {
 
-    //     Articles articles = articlesRepository.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+        Articles articles = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
 
-    //     articles.setTitle(incoming.getTitle());
-    //     articles.setUrl(incoming.getUrl());
-    //     articles.setExplanation(incoming.getExplanation());
-    //     articles.setEmail(incoming.getEmail());
-    //     articles.setDateAdded(incoming.getDateAdded());
+        articles.setTitle(incoming.getTitle());
+        articles.setUrl(incoming.getUrl());
+        articles.setExplanation(incoming.getExplanation());
+        articles.setEmail(incoming.getEmail());
+        articles.setDateAdded(incoming.getDateAdded());
 
-    //     articlesRepository.save(articles);
+        articlesRepository.save(articles);
 
-    //     return articles;
-    // }
+        return articles;
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -59,12 +59,11 @@ public class ArticlesControllerTests extends ControllerTestCase {
                             .andExpect(status().is(200)); // logged
     }
 
-    // For step 4
-    // @Test
-    // public void logged_out_users_cannot_get_by_id() throws Exception {
-    //         mockMvc.perform(get("/api/articles?id=7"))
-    //                         .andExpect(status().is(403)); // logged out users can't get by id
-    // }
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(get("/api/articles?id=7"))
+                            .andExpect(status().is(403)); // logged out users can't get by id
+    }
 
     // Authorization tests for /api/articles/post
     // (Perhaps should also have these for put and delete)
@@ -83,54 +82,54 @@ public class ArticlesControllerTests extends ControllerTestCase {
     }
     // // Tests with mocks for database actions
 
-    // @WithMockUser(roles = { "USER" })
-    // @Test
-    // public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
 
-    //         // arrange
-    //         LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+            // arrange
+            LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
 
-            // Articles articles = Articles.builder()
-            //                 .title("bi - test01: Nexustentialism")
-            //                 .url("https://dailynexus.com/2025-04-17/bingo-your-next-professor-may-be-a-lottery-hire/")
-            //                 .explanation("This is the first post added to the test")
-            //                 .email("binouye@ucsb.edu")
-            //                 .dateAdded(ldt1)
-            //                 .build();
+            Articles articles = Articles.builder()
+                            .title("bi - test01: Nexustentialism")
+                            .url("https://dailynexus.com/2025-04-17/bingo-your-next-professor-may-be-a-lottery-hire/")
+                            .explanation("This is the first post added to the test")
+                            .email("binouye@ucsb.edu")
+                            .dateAdded(ldt)
+                            .build();
 
-            // when(articlesRepository.findById(eq(7L))).thenReturn(Optional.of(articles));
+            when(articlesRepository.findById(eq(7L))).thenReturn(Optional.of(articles));
 
-    //         // act
-    //         MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
-    //                         .andExpect(status().isOk()).andReturn();
+            // act
+            MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
+                            .andExpect(status().isOk()).andReturn();
 
-    //         // assert
+            // assert
 
-    //         verify(articlesRepository, times(1)).findById(eq(7L));
-    //         String expectedJson = mapper.writeValueAsString(articles);
-    //         String responseString = response.getResponse().getContentAsString();
-    //         assertEquals(expectedJson, responseString);
-    // }
+            verify(articlesRepository, times(1)).findById(eq(7L));
+            String expectedJson = mapper.writeValueAsString(articles);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
 
-    // @WithMockUser(roles = { "USER" })
-    // @Test
-    // public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
 
-    //         // arrange
+            // arrange
 
-    //         when(articlesRepository.findById(eq(7L))).thenReturn(Optional.empty());
+            when(articlesRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
-    //         // act
-    //         MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
-    //                         .andExpect(status().isNotFound()).andReturn();
+            // act
+            MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
+                            .andExpect(status().isNotFound()).andReturn();
 
-    //         // assert
+            // assert
 
-    //         verify(articlesRepository, times(1)).findById(eq(7L));
-    //         Map<String, Object> json = responseToJson(response);
-    //         assertEquals("EntityNotFoundException", json.get("type"));
-    //         assertEquals("Articles with id 7 not found", json.get("message"));
-    // }
+            verify(articlesRepository, times(1)).findById(eq(7L));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("Articles with id 7 not found", json.get("message"));
+    }
 
     @WithMockUser(roles = { "USER" })
     @Test


### PR DESCRIPTION
### Overview
This PR adds a PUT endpoint for `Articles` database.

### Changes Made
- Implemented logic to edit single articles instance by id.
- Added corresponding unit tests in ArticleControllerTests.java.
- Synced changes with Dokku at team01-dev-bryceinouye.

### Testing Instructions
1. Running locally
You can test this by running on localhost and going to the **Swagger API Links**. Here, scroll down to the `Articles` section to test the `PUT` endpoint.
![image](https://github.com/user-attachments/assets/763cd774-beda-4060-8634-2ea6e6f5e68c) You can also run the command `mvn test jacoco:report` and review the report at `target/site/jacoco/index.html`.  
![image](https://github.com/user-attachments/assets/00b3f8cc-7e76-49fb-a3f4-f8ba460434d2)

2. Running on Dokku
Similar to 1, you can test this by running the [web application ](https://team01-dev-bryceinouye.dokku-15.cs.ucsb.edu/) and going to the **Swagger API Links**. From there, scroll down to the `Articles` section to test the `PUT` endpoint.

### Extra Information
Closes #41