### PR TITLE
perryjirakit - create database table for recommendation requests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a RecommendationRequest.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "RecommendationRequest")
+public class RecommendationRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+
+  private String requesterEmail;
+  private String professorEmail;
+  private String explanation;
+  private LocalDateTime dateRequested;
+  private LocalDateTime dateNeeded;
+  boolean done;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The RecommendationRequestRepository is a repository for RecommendationRequest entities.
+ */
+
+@Repository
+public interface RecommendationRequestRepository extends CrudRepository<RecommendationRequest, Long> {
+
+}

--- a/src/main/resources/db/migration/changes/RecommendationRequests.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequests.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "RecommendationRequest-1",
+          "author": "perryjirakit",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "RECOMMENDATIONREQUESTS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "RECOMMENDATIONREQUESTS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "PROFESSOR_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REQUESTED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_NEEDED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DONE",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "RECOMMENDATIONREQUESTS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #20 

In this pull request, we add a database tables that represents a Recommendation Request, with the following fields:
```
String requesterEmail
String professorEmail
String explanation
LocalDateTime dateRequested
LocalDateTime dateNeeded
boolean done
```

You can test this by running on localhost and looking for the Recommendation Requests table on the h2-console
![image](https://github.com/user-attachments/assets/c621b20b-b2aa-4447-867c-88a552898cfa)

You can also test this by running on dokku and connecting to the postgres database and running \dt

```
jthampiratwong@dokku-15:~$ dokku postgres:connect team01-dev-perryjirakit-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_perryjirakit_db=# \dt
                   List of relations
 Schema |           Name            | Type  |  Owner   
--------+---------------------------+-------+----------
 public | articles                  | table | postgres
 public | databasechangelog         | table | postgres
 public | databasechangeloglock     | table | postgres
 public | helprequests              | table | postgres
 public | menuitemreviews           | table | postgres
 public | recommendationrequests    | table | postgres
 public | restaurants               | table | postgres
 public | ucsbdates                 | table | postgres
 public | ucsbdiningcommons         | table | postgres
 public | ucsbdiningcommonsmenuitem | table | postgres
 public | users                     | table | postgres
(11 rows)

team01_dev_perryjirakit_db=# 
```